### PR TITLE
fix: Improve alignment of metric cards (400+ and 24/7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,25 +311,25 @@ CHANGES SUMMARY:
           <div class="space-y-6 slide-in-left" data-animate>
             <p class="text-lg text-gray-700">With CAPY Technologies, deploy custom, powerful automations in a single day and watch your team reclaim hundreds of hours each month.</p>
             <div class="grid grid-cols-3 gap-4">
-              <div class="bg-white p-6 rounded-lg shadow text-center scale-in stagger-1" data-animate>
-                <svg class="w-8 h-8 text-amber-500 mx-auto mb-2" fill="currentColor" viewBox="0 0 20 20">
+              <div class="bg-white p-6 rounded-lg shadow text-center scale-in stagger-1 flex flex-col items-center justify-center min-h-[140px]" data-animate>
+                <svg class="w-8 h-8 text-amber-500 mb-2" fill="currentColor" viewBox="0 0 20 20">
                   <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path>
                 </svg>
-                <p class="text-3xl font-bold text-blue-800">1</p>
+                <p class="text-3xl font-bold text-blue-800 leading-none">1</p>
                 <p class="mt-2 text-sm text-gray-600">Day Setup</p>
               </div>
-              <div class="bg-white p-6 rounded-lg shadow text-center scale-in stagger-2" data-animate>
-                <svg class="w-8 h-8 text-amber-500 mx-auto mb-2" fill="currentColor" viewBox="0 0 20 20">
+              <div class="bg-white p-6 rounded-lg shadow text-center scale-in stagger-2 flex flex-col items-center justify-center min-h-[140px]" data-animate>
+                <svg class="w-8 h-8 text-amber-500 mb-2" fill="currentColor" viewBox="0 0 20 20">
                   <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path>
                 </svg>
-                <p class="text-3xl font-bold text-blue-800">400+</p>
+                <p class="text-3xl font-bold text-blue-800 leading-none">400+</p>
                 <p class="mt-2 text-sm text-gray-600">Hours Saved</p>
               </div>
-              <div class="bg-white p-6 rounded-lg shadow text-center scale-in stagger-3" data-animate>
-                <svg class="w-8 h-8 text-amber-500 mx-auto mb-2" fill="currentColor" viewBox="0 0 20 20">
+              <div class="bg-white p-6 rounded-lg shadow text-center scale-in stagger-3 flex flex-col items-center justify-center min-h-[140px]" data-animate>
+                <svg class="w-8 h-8 text-amber-500 mb-2" fill="currentColor" viewBox="0 0 20 20">
                   <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"></path>
                 </svg>
-                <p class="text-3xl font-bold text-blue-800">24/7</p>
+                <p class="text-3xl font-bold text-blue-800 leading-none">24/7</p>
                 <p class="mt-2 text-sm text-gray-600">Uptime</p>
               </div>
             </div>


### PR DESCRIPTION
- Added flexbox layout to metric cards for better alignment
- Set minimum height (min-h-[140px]) to ensure consistent card heights
- Added leading-none to numbers for tighter text spacing
- Centered content vertically and horizontally within each card
- Removed mx-auto from icons since flexbox handles centering